### PR TITLE
Include .groovy files

### DIFF
--- a/src/main/java/org/eclipse/collections/tools/Converter.java
+++ b/src/main/java/org/eclipse/collections/tools/Converter.java
@@ -26,7 +26,7 @@ import org.eclipse.collections.impl.factory.Maps;
 
 public class Converter
 {
-    private static final ImmutableList<String> FILE_SCOPE = Lists.immutable.of(".java", ".xml", "gradle");
+    private static final ImmutableList<String> FILE_SCOPE = Lists.immutable.of(".java", ".xml", "gradle", ".groovy");
     private static final ImmutableMap<String, String> CONVERSION_MAP = Maps.immutable.with(
             "com\\.gs", "org\\.eclipse",
             "com\\.goldmansachs", "org\\.eclipse\\.collections",


### PR DESCRIPTION
Just noticed that some of our .groovy file's imports were not converted. This seems to resolve that. 

We are not heavy groovy users so I don't know if this is an exhaustive fix but it worked for our case which is Testing/Spock heavy.  